### PR TITLE
Add ability to specify a seed time

### DIFF
--- a/spec/ulid_spec.cr
+++ b/spec/ulid_spec.cr
@@ -46,5 +46,15 @@ describe ULID do
         (ulid_2 > ulid_1).should be_true
       end
     end
+
+    it "should be seedable" do
+      1000.times do
+        ulid_1 = ULID.generate
+        sleep 1.millisecond
+        ulid_2 = ULID.generate(Time.now - 1.second)
+
+        (ulid_2 < ulid_1).should be_true
+      end
+    end
   end
 end

--- a/src/ulid.cr
+++ b/src/ulid.cr
@@ -4,10 +4,10 @@ module ULID
   extend self
 
   # Crockford's Base32
-  private ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+  private ENCODING     = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
   private ENCODING_LEN = ENCODING.size
-  private TIME_LEN = 10
-  private RANDOM_LEN = 16
+  private TIME_LEN     = 10
+  private RANDOM_LEN   = 16
 
   # Generate a ULID
   #
@@ -15,8 +15,8 @@ module ULID
   # ULID.generate
   # # => "01B3EAF48P97R8MP9WS6MHDTZ3"
   # ```
-  def generate : String
-    encode_time(Time.now, TIME_LEN) + encode_random(RANDOM_LEN)
+  def generate(seed_time : Time = Time.now) : String
+    encode_time(seed_time, TIME_LEN) + encode_random(RANDOM_LEN)
   end
 
   private def encode_time(now : Time, len : Int32) : String


### PR DESCRIPTION
Hi,

First of all, thanks for this library :)

I have noticed that at the moment, the library doesn't offer the ability to specify a seed time when generating a new ulid (like do the [original implementation](https://github.com/ulid/javascript#seed-time)).

How do you feel about it ? Anyway, this PR add this feature with the related spec.